### PR TITLE
调整星尘流星汉化和野餐篮

### DIFF
--- a/src/main/java/me/profelements/dynatech/items/backpacks/PicnicBasket.java
+++ b/src/main/java/me/profelements/dynatech/items/backpacks/PicnicBasket.java
@@ -54,6 +54,7 @@ public class PicnicBasket extends SlimefunBackpack {
         //Returns Stuff, maybe will figure this out later.
         defaultBlacklist.add(Material.SUSPICIOUS_STEW);
         defaultBlacklist.add(Material.MUSHROOM_STEW);
+        defaultBlacklist.add(Material.BEETROOT_SOUP);
         defaultBlacklist.add(Material.RABBIT_STEW);
         defaultBlacklist.add(Material.HONEY_BOTTLE);
 

--- a/src/main/java/me/profelements/dynatech/items/misc/StarDustMeteor.java
+++ b/src/main/java/me/profelements/dynatech/items/misc/StarDustMeteor.java
@@ -22,7 +22,7 @@ public class StarDustMeteor extends UnplaceableBlock implements GEOResource {
         PlayerHead.getItemStack(PlayerSkin.fromHashCode("c482d1ba4bdac990f6ea987703587fd79fe55555363251984679d4f279cc0c2a")),
         "&6星尘流星",
         "",
-        "&f从山地或恶地(平顶山)生物群系中",
+        "&f从草甸或恶地(平顶山)生物群系中",
         "&f使用 GEO 矿机开采"
     );
 

--- a/src/main/java/me/profelements/dynatech/listeners/PicnicBasketListener.java
+++ b/src/main/java/me/profelements/dynatech/listeners/PicnicBasketListener.java
@@ -144,7 +144,8 @@ public class PicnicBasketListener implements Listener {
                         }
                     } else if (material == Material.COOKIE || material == Material.MELON_SLICE
                             || material == Material.CHICKEN || material == Material.COD || material == Material.MUTTON
-                            || material == Material.SALMON || material == Material.SWEET_BERRIES) {
+                            || material == Material.SALMON || material == Material.SWEET_BERRIES
+                            || material == Material.GLOW_BERRIES) {
 
                         if (p.getFoodLevel() <= 18) {
                             p.setFoodLevel(p.getFoodLevel() + 2);


### PR DESCRIPTION
根据星辰流星的分布调整，修改描述。

甜菜汤现在不能放入野餐篮中。

发光浆果现在可以被野餐篮正常使用。